### PR TITLE
Add README for OctoAcme Project Management Docs

### DIFF
--- a/docs/octoacme-project-management-readme.md
+++ b/docs/octoacme-project-management-readme.md
@@ -1,0 +1,28 @@
+# OctoAcme Project Management Docs
+
+This README is the central hub for OctoAcme's project management process documentation. It summarizes the key workflows, roles, communication strategies, and quality assurance practices, and includes links to all foundational process docs in the `docs/` folder.
+
+## Project Management Process Overview
+
+OctoAcme’s project lifecycle starts with a structured initiation phase—defining the problem, validating stakeholders and success metrics—followed by detailed planning where work is broken into incremental deliverables, the backlog is prioritized, dependencies and risks are documented, and a Definition of Done guides quality. Execution is managed with a standard project board (Backlog, Ready, In Progress, In Review, QA, Done), regular standups, sprint demos, and tracking of metrics such as velocity and burndown. Releases are governed by automated and manual checklists, staged smoke testing, release notes, and clear rollback protocols for incidents.
+
+Project roles are clearly assigned to ensure ownership and accountability: Product Managers own backlog and outcomes, Project Managers coordinate delivery and risk, Developers build and test solutions, and QA validates acceptance. All team members collaborate through planned rhythms—daily standups, weekly delivery syncs, monthly stakeholder briefings, and established escalation paths for blockers (team to PM to Product Lead to Sponsor). Action items from retrospectives are tracked to drive continuous improvement.
+
+Quality assurance is a combination of automated testing in CI (unit, integration, and security scans) and manual QA prior to acceptance. Risk management practices include maintaining a risk register and regularly communicating updates via status templates and incident reports. Each phase closes with a retrospective to capture lessons and assign improvements to the backlog.
+
+## Key Process Documents
+
+- [Project Management Overview](docs/octoacme-project-management-overview.md)
+- [Project Initiation Guide](docs/octoacme-project-initiation.md)
+- [Project Planning Guide](docs/octoacme-project-planning.md)
+- [Execution & Tracking Guide](docs/octoacme-execution-and-tracking.md)
+- [Risk Management & Communication](docs/octoacme-risks-and-communication.md)
+- [Release & Deployment Guide](docs/octoacme-release-and-deployment.md)
+- [Retrospective & Continuous Improvement](docs/octoacme-retrospective-and-continuous-improvement.md)
+- [Roles and Personas](docs/octoacme-roles-and-personas.md)
+
+## Acceptance Checklist
+
+- [ ] Content aligns with existing process docs
+- [ ] Update improves clarity or closes a documented gap
+- [ ] Proposed content has been reviewed with stakeholders (if needed)


### PR DESCRIPTION
Adds a central README file summarizing project management processes and providing links to all foundational docs in the docs/ folder. Closes #2. @OthmanFrDev added as reviewer.